### PR TITLE
Fix optional copy-assignment leak/self-assignment bug and set iterator types (#31)

### DIFF
--- a/include/optional.h
+++ b/include/optional.h
@@ -54,7 +54,10 @@ using optional_t = std::optional<T>;
 
         optional& operator=(optional const& other)
         {
-            _value = nullptr;
+            if (this == &other) {
+                return *this;
+            }
+            reset();
             if (other.has_value()) {
                 _value = new T{other.value()};
             }

--- a/include/set.h
+++ b/include/set.h
@@ -1065,25 +1065,25 @@ namespace fcpp {
         }
 
         // Returns the begin iterator, useful for other standard library algorithms
-        [[nodiscard]] typename std::set<TKey>::iterator begin()
+        [[nodiscard]] typename std::set<TKey, TCompare>::iterator begin()
         {
             return m_set.begin();
         }
 
         // Returns the const begin iterator, useful for other standard library algorithms
-        [[nodiscard]] typename std::set<TKey>::const_iterator begin() const
+        [[nodiscard]] typename std::set<TKey, TCompare>::const_iterator begin() const
         {
             return m_set.begin();
         }
 
         // Returns the end iterator, useful for other standard library algorithms
-        [[nodiscard]] typename std::set<TKey>::iterator end()
+        [[nodiscard]] typename std::set<TKey, TCompare>::iterator end()
         {
             return m_set.end();
         }
 
         // Returns the const end iterator, useful for other standard library algorithms
-        [[nodiscard]] typename std::set<TKey>::const_iterator end() const
+        [[nodiscard]] typename std::set<TKey, TCompare>::const_iterator end() const
         {
             return m_set.end();
         }

--- a/tests/optional_test.cc
+++ b/tests/optional_test.cc
@@ -108,3 +108,14 @@ TEST(OptionalTest, CopyConstructorNullTest)
     const optional_t<int> v1(v2);
     EXPECT_FALSE(v1.has_value());
 }
+
+TEST(OptionalTest, SelfAssignmentTest)
+{
+    optional_t<int> v(5);
+    // Assign through an alias so the self-assignment is not diagnosed by the
+    // compiler but still exercises operator=(optional const&) with this == &other.
+    const optional_t<int>& alias = v;
+    v = alias;
+    EXPECT_TRUE(v.has_value());
+    EXPECT_EQ(5, v.value());
+}


### PR DESCRIPTION
## Summary

Fixes the two robustness defects tracked in #31. Both are small, self-contained correctness/safety fixes with no behavior change for valid usage.

## 1. `optional::operator=` — memory leak and self-assignment value loss

`include/optional.h` (the **pre-C++17 fallback** `optional`; C++17 uses `std::optional`)

```cpp
optional& operator=(optional const& other)
{
    _value = nullptr;                 // leaks the existing allocation if non-null
    if (other.has_value()) {
        _value = new T{other.value()};
    }
    return *this;
}
```

Two problems:
- **Leak:** copy-assigning onto an `optional` that already holds a value overwrites `_value` without `delete`ing the previous heap allocation.
- **Self-assignment value loss (worse):** `_value = nullptr` runs first, so for `v = v` the following `other.has_value()` reads the just-nulled pointer, returns `false`, and the value is silently **dropped** (and the original leaked).

**Fix** — self-assignment guard, then `reset()` (which `delete`s the old value) before copying:

```cpp
optional& operator=(optional const& other)
{
    if (this == &other) {
        return *this;
    }
    reset();
    if (other.has_value()) {
        _value = new T{other.value()};
    }
    return *this;
}
```

This mirrors the existing `operator=(T const&)` overload, which already calls `reset()` first.

## 2. `set` iterator accessors — comparator-independent iterator type

`include/set.h`

```cpp
[[nodiscard]] typename std::set<TKey>::iterator begin()   // member is std::set<TKey, TCompare>
```

The four `begin()`/`end()` overloads declared their return types as `std::set<TKey>::iterator` (default comparator), while the underlying member is `std::set<TKey, TCompare>`. It compiles today only because a `std::set`'s iterator type happens not to depend on its comparator in current implementations — that's not guaranteed by the standard. Spelled the return types correctly with `TCompare`.

## Tests

Added `OptionalTest.SelfAssignmentTest`. I confirmed it **fails on the old code** (value dropped → `value()` aborts) and **passes with the fix**.

## Verification

Built and ran the full suite under **Debug & Release × C++11 & C++17** — all green (302 tests in C++17, 286 in C++11). The C++11 configuration is what exercises the fallback `optional`.

## Scope note

The original #31 report also listed `lazy_set::zip(vector)` "dropping the comparator" and some cosmetic items. On inspection those are not bugs (the vector-zip overloads have no `UCompare` to preserve; `std::less` is the correct dedup ordering, consistent with `vector::distinct`), so they were intentionally left out — see the updated issue for details.

Closes #31.

https://claude.ai/code/session_011y3XcVg3UCcgi5JMEo2tso